### PR TITLE
Suppress warnings about missing columns in art reg

### DIFF
--- a/_admin/js/art.js
+++ b/_admin/js/art.js
@@ -90,6 +90,7 @@ function data_obtained(data)
         len = len-1;
         toggles.append('<a class="toggle-vis" data-column="'+len+'">'+var_name+'</a> | ');
     }
+    $.fn.dataTable.ext.errMode = 'none';
     $('#art').dataTable({
         'data': [],
         'columns': columns


### PR DESCRIPTION
The jquery datatable spits out alerts anytime it encounters data that is missing in a registration but present in another, such as when a registration isn't complete yet. This causes the alert to be suppressed as it isn't helpful in this case. 